### PR TITLE
Bump pyyaml to 6.0.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ packages =
   vyos_modular.iso_customize
   vyos_modular.templates
 install_requires =
-  pyyaml==6.0
+  pyyaml==6.0.1
   Jinja2==3.1.2
 
 [options.package_data]


### PR DESCRIPTION
on some newer pip/python version, [pyyaml](https://github.com/yaml/pyyaml/issues/724) refuse to install. The 6.0.1 pyyaml version fix that problem. There is no breaking change and work with vyos-modular (I have tested it)